### PR TITLE
chore: add docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+Dockerfile
+docker-compose.yml
+docker-compose.dev.yml
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Use Nginx to serve static files
+FROM nginx:alpine
+
+# Copy project files to Nginx html directory
+COPY . /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -62,3 +62,25 @@ There are multiple reasons for the switch, including, but not limited to, the fo
 
 ## License
 Bingo Master Board is licensed under the MIT License.
+
+## Run with Docker
+
+You can run Bingo Master Board inside Docker containers.
+
+### Production
+Build and start the container:
+
+```bash
+ docker compose up --build
+```
+
+Then open http://localhost:8080.
+
+### Development
+Use the development configuration to see changes in real time:
+
+```bash
+ docker compose -f docker-compose.dev.yml up
+```
+
+The source code is mounted inside the container so updates are served immediately.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"


### PR DESCRIPTION
## Summary
- add Dockerfile to serve static site with Nginx
- provide docker compose configs for production and dev
- document container usage in README

## Testing
- `docker-compose -f docker-compose.yml config`
- `docker-compose -f docker-compose.dev.yml config`
- `docker build -t bingo-master-board-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688d99d17f78832ebe9cedfce1434a4b