### PR TITLE
Add background image selection

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -783,6 +783,25 @@ color:gray;
   background-color:rgba(0,0,0,0.05);
 }
 
+.themeImage {
+  display:inline-block;
+  width:64px;
+  height:64px;
+  border-radius:12px;
+  background-size:cover;
+  background-position:center;
+  border:3px solid transparent;
+  cursor:pointer;
+}
+
+.themeImage:hover {
+  border-color:rgba(0,0,0,0.15);
+}
+
+.themeImageActive {
+  border-color:rgba(0,0,0,0.5);
+}
+
 #classic {
   color:rgb(148,138,84);
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,10 +3,13 @@ const fixedHeight = document.getElementById("area").offsetHeight;
 let isFullScreen = false;
 let loadedMasterBoard = false;
 let keyPressed = false;
+// Add image filenames placed in assets/backgrounds to this array
+const backgroundImages = []; 
 
 let saveData = {
   drawnBingoBalls: [],
   themeColor: "classic",
+  backgroundImage: "",
   bingoStyle: "ball",
   blockerEnabled: false,
   lastActionWasRemove: false,
@@ -283,8 +286,14 @@ function changeBG(color) {
   } else {
     newColor = "radial-gradient(#f7eaab, #bfbb73)";
   }
-	document.getElementById("area").style.background=newColor;
-	document.getElementById("fader").style.background=newColor;
+  if (saveData.backgroundImage) {
+    const bgUrl = `url('./assets/backgrounds/${saveData.backgroundImage}') center/cover no-repeat`;
+    document.getElementById("area").style.background = bgUrl;
+    document.getElementById("fader").style.background = bgUrl;
+  } else {
+    document.getElementById("area").style.background = newColor;
+    document.getElementById("fader").style.background = newColor;
+  }
 }
 
 function activateBingoBall(bingoIDNum) {
@@ -649,6 +658,7 @@ function setUpSettings() {
   document.getElementById("purple").style.backgroundColor = "";
   document.getElementById("bingoStyleBall").style.backgroundColor = "";
   document.getElementById("bingoStyleVintage").style.backgroundColor = "";
+  populateBackgroundImageOptions();
   if (saveData.themeColor === "classic") {
     document.getElementById("classic").style.backgroundColor = "rgba(148,138,84,0.28)";
   } else if (saveData.themeColor === "red") {
@@ -671,6 +681,39 @@ function changeBackgroundColor(theColor) {
   saveData.themeColor = theColor;
   save();
   setUpSettings();
+  changeBG(saveData.themeColor);
+}
+
+function changeBackgroundImage(theImage) {
+  saveData.backgroundImage = theImage;
+  save();
+  setUpSettings();
+  changeBG(saveData.themeColor);
+}
+
+function populateBackgroundImageOptions() {
+  const container = document.getElementById("backgroundImageSelection");
+  if (!container) { return; }
+  container.innerHTML = "";
+  const noneSpan = document.createElement('span');
+  noneSpan.id = 'bgNone';
+  noneSpan.className = 'themeColor';
+  noneSpan.textContent = 'None';
+  noneSpan.onclick = () => { changeBackgroundImage(''); };
+  if (saveData.backgroundImage === "") {
+    noneSpan.style.backgroundColor = "rgba(0,0,0,0.15)";
+  }
+  container.appendChild(noneSpan);
+  for (let i=0;i<backgroundImages.length;i+=1) {
+    const span = document.createElement('span');
+    span.className = 'themeImage';
+    span.style.backgroundImage = `url('./assets/backgrounds/${backgroundImages[i]}')`;
+    span.onclick = () => { changeBackgroundImage(backgroundImages[i]); };
+    if (saveData.backgroundImage === backgroundImages[i]) {
+      span.classList.add('themeImageActive');
+    }
+    container.appendChild(span);
+  }
 }
 
 function toggleWinningPattern(theNumber) {

--- a/index.html
+++ b/index.html
@@ -445,6 +445,8 @@
                 <span class="themeColor" id="blue" onclick="changeBackgroundColor('blue');">Blue</span>
                 <span class="themeColor" id="purple" onclick="changeBackgroundColor('purple');">Purple</span>
               </p>
+              <p><strong>Background Image</strong></p>
+              <p class="themeSelection" id="backgroundImageSelection"></p>
               <p><strong>Bingo Numbers</strong></p>
               <p style="display:flex;justify-content:center;">
                 <span id="bingoStyleBall" onclick="changeBingoStyle('ball');">


### PR DESCRIPTION
## Summary
- allow choosing background images from Themes page
- save background image selection and apply it on the board
- remove example background images from repository

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d9f64f59c832eab972c0a010f39da