### PR TITLE
Improve theme menu layout and readability

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -170,10 +170,10 @@ body {
   display:none;
   height:100%;
   grid-template-columns:100%;
-  grid-template-rows: 96px 1fr 77px;
+  grid-template-rows: 96px 1fr;
   grid-template-areas: "helpHeader"
-                      "helpContent"
-                      "helpFooter";
+                      "helpContent";
+  position:relative;
 }
 
 #winningPatternSlide {
@@ -299,6 +299,23 @@ h2 {
 
 .helpFooterLabel:hover {
   color:#4297b7;
+}
+
+.backButton {
+  position:absolute;
+  top:10px;
+  left:10px;
+  cursor:pointer;
+  color:#376092;
+  transition:color 0.15s;
+}
+
+.backButton:hover {
+  color:#4297b7;
+}
+
+#overlaySlider {
+  width:200px;
 }
 
 .helpPointer {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,6 +10,7 @@ let saveData = {
   drawnBingoBalls: [],
   themeColor: "classic",
   backgroundImage: "",
+  overlayOpacity: 50,
   bingoStyle: "ball",
   blockerEnabled: false,
   lastActionWasRemove: false,
@@ -268,28 +269,37 @@ function changeFullScreenImg() {
 
 function changeBG(color) {
   let newColor;
+  let overlayRGB;
   if (color === "classic") {
     newColor = "#d1cc85";
+    overlayRGB = "209,204,133";
     document.getElementById("blocker").style.backgroundImage = "linear-gradient(#c4bd97, #948A54)";
   } else if (color === "red") {
     newColor = "rgb(253, 166, 166)";
+    overlayRGB = "253,166,166";
     document.getElementById("blocker").style.backgroundImage = "linear-gradient(#ed9f9d, #c0504d)";
   } else if (color === "green") {
     newColor = "rgb(150, 206, 129)";
+    overlayRGB = "150,206,129";
     document.getElementById("blocker").style.backgroundImage = "linear-gradient(#a9c571, #77933c)";
   } else if (color === "blue") {
     newColor = "rgb(139, 199, 226)";
+    overlayRGB = "139,199,226";
     document.getElementById("blocker").style.backgroundImage = "linear-gradient(#9abce6, #558ed5)";
   } else if (color === "purple") {
     newColor = "rgb(189, 176, 216)";
+    overlayRGB = "189,176,216";
     document.getElementById("blocker").style.backgroundImage = "linear-gradient(#b3a2c7, #725892)";
   } else {
     newColor = "radial-gradient(#f7eaab, #bfbb73)";
+    overlayRGB = "247,234,171";
   }
   if (saveData.backgroundImage) {
     const bgUrl = `url('./assets/backgrounds/${saveData.backgroundImage}') center/cover no-repeat`;
-    document.getElementById("area").style.background = bgUrl;
-    document.getElementById("fader").style.background = bgUrl;
+    const alpha = saveData.overlayOpacity / 100;
+    const overlay = `linear-gradient(rgba(${overlayRGB}, ${alpha}), rgba(${overlayRGB}, ${alpha})), ${bgUrl}`;
+    document.getElementById("area").style.background = overlay;
+    document.getElementById("fader").style.background = overlay;
   } else {
     document.getElementById("area").style.background = newColor;
     document.getElementById("fader").style.background = newColor;
@@ -675,6 +685,10 @@ function setUpSettings() {
   } else if (saveData.bingoStyle === "vintage") {
     document.getElementById("bingoStyleVintage").style.backgroundColor = "rgba(0,0,0,0.15)";
   }
+  const overlaySlider = document.getElementById('overlaySlider');
+  if (overlaySlider) {
+    overlaySlider.value = saveData.overlayOpacity;
+  }
 }
 
 function changeBackgroundColor(theColor) {
@@ -688,6 +702,12 @@ function changeBackgroundImage(theImage) {
   saveData.backgroundImage = theImage;
   save();
   setUpSettings();
+  changeBG(saveData.themeColor);
+}
+
+function changeOverlayOpacity(value) {
+  saveData.overlayOpacity = parseInt(value, 10);
+  save();
   changeBG(saveData.themeColor);
 }
 

--- a/index.html
+++ b/index.html
@@ -431,6 +431,9 @@
       </div>
 
       <div id="settingsSlide">
+        <div class="backButton" onclick="hide('settingsSlide');show('masterBoardSlide', 'grid');">
+          Go Back
+        </div>
         <h2>Themes</h2>
         <div class="helpContent">
           <div class="flexCenter">
@@ -447,6 +450,8 @@
               </p>
               <p><strong>Background Image</strong></p>
               <p class="themeSelection" id="backgroundImageSelection"></p>
+              <p><strong>Overlay Transparency</strong></p>
+              <p><input type="range" id="overlaySlider" min="0" max="100" oninput="changeOverlayOpacity(this.value)"></p>
               <p><strong>Bingo Numbers</strong></p>
               <p style="display:flex;justify-content:center;">
                 <span id="bingoStyleBall" onclick="changeBingoStyle('ball');">
@@ -457,11 +462,6 @@
                 </span>
               </p>
             </div>
-          </div>
-        </div>
-        <div class="helpFooter">
-          <div class="helpFooterLabel" onclick="hide('settingsSlide');show('masterBoardSlide', 'grid');">
-            Go Back
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Move the theme menu's back link to the top-left and add an overlay transparency slider.
- Style the theme menu for the new back button and overlay slider.
- Use the theme color as a configurable overlay above background images for better readability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688da83cbb4c832ebe0ec58d5723a057