### PR TITLE
Traducir interfaz al español y ajustar transparencia de números inactivos

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -566,7 +566,7 @@ margin:0.5em 0;
 .bigBingoBallClass {
   background:#9b9b9b;
   border:2.5px solid #333;
-  opacity:0.21;
+  opacity:0.4;
 }
 
 #bigBingoBall {
@@ -579,7 +579,7 @@ margin:0.5em 0;
 }
 
 .bigBingoBallClass:hover {
-  opacity:0.35;
+  opacity:0.7;
 }
 
 #bigBingoLetter {
@@ -656,11 +656,11 @@ margin:0.5em 0;
   border-width: 1px;
   border-color:#333;
   color:#000;
-  opacity:0.21;
+  opacity:0.4;
 }
 
 .bingoBallBall:hover {
-  opacity:0.54;
+  opacity:0.7;
 }
 
 .bingoBallBallActiveB {
@@ -718,11 +718,11 @@ color:gray;
   font-size:52px;
   cursor:pointer;
   color:#000;
-  opacity:0.17;
+  opacity:0.35;
 }
 
 .bingoBallVintage:hover {
-  opacity:0.54;
+  opacity:0.7;
 }
 
 .bingoBallVintageActive {

--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Bingo Master Board</title>
+    <title>Tablero Maestro de Bingo</title>
 		<meta charset="UTF-8">
-		<meta name="description" content="Host and manage Bingo games on the Web">
+                <meta name="description" content="Organiza y administra juegos de Bingo en la Web">
 		<meta name="author" content="Games by Tim">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 		<link rel="shortcut icon" href="assets/img/favicon.ico" />
 		<meta name="format-detection" content="telephone=no">
-		<meta name="apple-mobile-web-app-title" content="Bingo Board">
+                <meta name="apple-mobile-web-app-title" content="Tablero de Bingo">
 		<link rel="apple-touch-icon" sizes="180x180" href="assets/img/appIcon.png">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 
@@ -20,8 +20,8 @@
 
     <noscript class="noscript">
       <div>
-        <p><strong>JavaScript is disabled.</strong></p>
-        <p>Please enable it to use Bingo Master Board.</p>
+        <p><strong>JavaScript está deshabilitado.</strong></p>
+        <p>Por favor habilítalo para usar Tablero Maestro de Bingo.</p>
       </div>
     </noscript>
 
@@ -52,8 +52,8 @@
           <g id="hex" onclick="randomDraw();">
           <polygon points="-52.5,45 52.5,45 77.5,0 52.5,-45 -52.5,-45 -77.5,0" stroke="rgb(94,87,52)" stroke-width="2">
           </polygon>
-            <text x="-41" y="-6" fill="#000" font-size="27">DRAW</text>
-            <text x="-33" y="26" fill="#000" font-size="27">BALL</text>
+            <text x="-46" y="-6" fill="#000" font-size="27">SACAR</text>
+            <text x="-30" y="26" fill="#000" font-size="27">BOLA</text>
           </g>
         </svg>
       </div>
@@ -76,41 +76,41 @@
               B I N G O
             </div>
             <div id="subheading">
-              Master Board
+              Tablero Maestro
             </div>
             <div id="titleSelection">
-              <div id="howToUse" onclick ="hide('titleSlide');show('howToUseSlide', 'grid');">How to Use</div>
-              <div id="goToMasterBoard" onclick="hide('titleSlide');show('masterBoardSlide', 'grid');">Master Board</div>
+              <div id="howToUse" onclick ="hide('titleSlide');show('howToUseSlide', 'grid');">Cómo usar</div>
+              <div id="goToMasterBoard" onclick="hide('titleSlide');show('masterBoardSlide', 'grid');">Tablero Maestro</div>
             </div>
           </div>
         </div>
         <div id="copyright">
-          <div id="copyrightLabel" onclick="hide('titleSlide');show('aboutCreditsSlide', 'grid');">Version 3.0.1 ~ ©2011-2018 Games by Tim ~ About/Credits</div>
+          <div id="copyrightLabel" onclick="hide('titleSlide');show('aboutCreditsSlide', 'grid');">Versión 3.0.1 ~ ©2011-2018 Games by Tim ~ Acerca/Créditos</div>
         </div>
       </div>
 
       <div id="howToUseSlide">
-        <h2>How to Use</h2>
+        <h2>Cómo usar</h2>
         <div class="helpNav">
           <div id="helpNavLine"></div>
-          <div class="helpNavText boldHelp" onclick="navHelp('Basics');" id="howToUseBasicsHeader">Basics</div>
-          <div class="helpNavText" onclick="navHelp('Basics 2');" id="howToUseBasics2Header">Basics 2</div>
-          <div class="helpNavText" onclick="navHelp('Tips & Tricks');" id="howToUseTipsTricksHeader">Tips & Tricks</div>
-          <div class="helpNavText" onclick="navHelp('Thank You');" id="howToUseThanksHeader">Thank You</div>
+          <div class="helpNavText boldHelp" onclick="navHelp('Basics');" id="howToUseBasicsHeader">Conceptos básicos</div>
+          <div class="helpNavText" onclick="navHelp('Basics 2');" id="howToUseBasics2Header">Conceptos básicos 2</div>
+          <div class="helpNavText" onclick="navHelp('Tips & Tricks');" id="howToUseTipsTricksHeader">Consejos y trucos</div>
+          <div class="helpNavText" onclick="navHelp('Thank You');" id="howToUseThanksHeader">Gracias</div>
         </div>
         <div class="helpLine"></div>
         <div class="helpContent">
           <div class="flexCenter" id="howToUseBasics" style="display:flex;">
             <div style="text-align:center;">
-              <p style="font-size:26px;"><strong>Bingo Master Board</strong> helps you host and manage your own Bingo games.</p>
+              <p style="font-size:26px;"><strong>Tablero Maestro de Bingo</strong> te ayuda a organizar y gestionar tus propios juegos de Bingo.</p>
               <p><img src="./assets/img/BingoScreenshot1.png" width="600" style="box-shadow:3px 3px 10px rgba(0,0,0,0.6);"></p>
-              <div style="position:absolute;left:85px;top:270px;font-size:26px;width:200px;">Set the winning Bingo pattern.</div>
+              <div style="position:absolute;left:85px;top:270px;font-size:26px;width:200px;">Establece el patrón ganador de Bingo.</div>
               <div class="helpPointer" style="left:290px;top:320px;width:92px;transform:rotate(10deg);"></div>
-              <div style="position:absolute;left:90px;top:390px;font-size:26px;width:190px;">Randomly draw a Bingo ball.</div>
+              <div style="position:absolute;left:90px;top:390px;font-size:26px;width:190px;">Saca al azar una bola de Bingo.</div>
               <div class="helpPointer" style="left:290px;top:420px;width:92px;transform:rotate(345deg);"></div>
-              <div style="position:absolute;left:85px;top:510px;font-size:26px;width:200px;">Clear the board for a new game.</div>
+              <div style="position:absolute;left:85px;top:510px;font-size:26px;width:200px;">Limpia el tablero para un nuevo juego.</div>
               <div class="helpPointer" style="left:187px;top:402px;width:280px;transform:rotate(285deg);"></div>
-              <div style="position:absolute;left:1000px;top:300px;font-size:26px;width:200px;">Make the board fullscreen.</div>
+              <div style="position:absolute;left:1000px;top:300px;font-size:26px;width:200px;">Haz que el tablero sea a pantalla completa.</div>
               <div class="helpPointer" style="left:928px;top:282px;width:70px;transform:rotate(210deg);"></div>
             </div>
           </div>
@@ -118,63 +118,63 @@
             <div style="text-align:center;">
               <p style="font-size:26px;">&nbsp;</p>
               <p><img src="./assets/img/BingoScreenshot2.png" width="600" style="box-shadow:3px 3px 10px rgba(0,0,0,0.6);"></p>
-              <div style="position:absolute;left:90px;top:240px;font-size:26px;width:200px;">Change how the board looks.</div>
+              <div style="position:absolute;left:90px;top:240px;font-size:26px;width:200px;">Cambia el aspecto del tablero.</div>
               <div class="helpPointer" style="left:295px;top:275px;width:96px;transform:rotate(347deg);"></div>
-              <div style="position:absolute;left:85px;top:370px;font-size:26px;width:210px;">Toggle the balls drawn/remaining counter.</div>
+              <div style="position:absolute;left:85px;top:370px;font-size:26px;width:210px;">Alterna el contador de bolas extraídas/restantes.</div>
               <div class="helpPointer" style="left:282px;top:470px;width:90px;transform:rotate(18deg);"></div>
-              <div style="position:absolute;left:60px;top:520px;font-size:26px;width:240px;">Hide the board for a tougher game.</div>
+              <div style="position:absolute;left:60px;top:520px;font-size:26px;width:240px;">Oculta el tablero para un juego más difícil.</div>
               <div class="helpPointer" style="left:300px;top:563px;width:78px;"></div>
-              <div style="position:absolute;left:1000px;top:300px;font-size:26px;width:210px;">Manually edit the board if you're drawing balls separately.</div>
+              <div style="position:absolute;left:1000px;top:300px;font-size:26px;width:210px;">Edita manualmente el tablero si estás sacando bolas por separado.</div>
               <div class="helpPointer" style="left:910px;top:312px;width:90px;transform:rotate(200deg);"></div>
               <div class="helpPointer" style="left:833px;top:402px;width:162px;transform:rotate(165deg);"></div>
             </div>
           </div>
           <div class="flexCenter" id="howToUseTipsTricks">
             <div style="text-align:center;">
-              <p style="font-size:27px;"><strong>Use keyboard shortcuts.</strong></p>
-              <p class="smallMargin" style="font-size:27px;">Draw balls with the <strong>space bar</strong>.</p>
-              <p class="smallMargin" style="font-size:27px;">Reset the board with the <strong>r key</strong>.</p>
-              <p style="font-size:23px;margin:1.5em 0 0.5em 0;"><strong>Other Shortcuts</strong></p>
+              <p style="font-size:27px;"><strong>Usa atajos de teclado.</strong></p>
+              <p class="smallMargin" style="font-size:27px;">Saca bolas con la <strong>barra espaciadora</strong>.</p>
+              <p class="smallMargin" style="font-size:27px;">Reinicia el tablero con la tecla <strong>r</strong>.</p>
+              <p style="font-size:23px;margin:1.5em 0 0.5em 0;"><strong>Otros atajos</strong></p>
               <div style="display:flex;align-items:center;justify-content:center;">
                 <div>
-                  <p class="smallMargin" style="font-size:23px;"><strong>f</strong> - Toggle fullscreen</p>
-                  <p class="smallMargin" style="font-size:23px;"><strong>t</strong> - Go to Themes page</p>
-                  <p class="smallMargin" style="font-size:23px;"><strong>w</strong> - Go to Winning Pattern page</p>
+                  <p class="smallMargin" style="font-size:23px;"><strong>f</strong> - Alternar pantalla completa</p>
+                  <p class="smallMargin" style="font-size:23px;"><strong>t</strong> - Ir a la página de temas</p>
+                  <p class="smallMargin" style="font-size:23px;"><strong>w</strong> - Ir a la página de patrón ganador</p>
                 </div>
                 <div style="width:30px;"></div>
                 <div>
-                  <p class="smallMargin" style="font-size:23px;"><strong>enter</strong> - Go to master board from title</p>
-                  <p class="smallMargin" style="font-size:23px;"><strong>v</strong> - Toggle balls drawn/remaining</p>
-                  <p class="smallMargin" style="font-size:23px;"><strong>x</strong> - Hide/show board</p>
+                  <p class="smallMargin" style="font-size:23px;"><strong>enter</strong> - Ir al tablero maestro desde el título</p>
+                  <p class="smallMargin" style="font-size:23px;"><strong>v</strong> - Alternar bolas extraídas/restantes</p>
+                  <p class="smallMargin" style="font-size:23px;"><strong>x</strong> - Ocultar/mostrar tablero</p>
                 </div>
               </div>
-              <p style="font-size:23px;">Add <em>?masterboard</em> to the end of the URL to quickly load the master board.</p>
+              <p style="font-size:23px;">Añade <em>?masterboard</em> al final de la URL para cargar rápidamente el tablero maestro.</p>
             </div>
           </div>
           <div class="flexCenter" id="howToUseThanks">
             <div style="text-align:center;font-size:26px;">
-              <p>Thanks for using Bingo Master Board! I really appreciate it.</p>
-              <p><strong>View the source code</strong> on <a href="https://github.com/TimTree/bingo-master-board" target="_blank">GitHub</a>.</p>
-              <p><strong>Send me a comment</strong> on the <a href="https://www.gamesbytim.com/2018/09/bingo-master-board-host-bingo-games-on.html" target="_blank">project description page</a>.</p>
-              <p><strong>Report bugs</strong> to the <a href="https://github.com/TimTree/bingo-master-board/issues" target="_blank">GitHub issues page</a>.</p>
-              <p><strong>See the project's <a class="textLink" onclick="hide('howToUseSlide');show('aboutCreditsSlide', 'grid');">About/Credits</a>.</strong></p>
+              <p>Gracias por usar Tablero Maestro de Bingo. Lo aprecio mucho.</p>
+              <p><strong>Ver el código fuente</strong> en <a href="https://github.com/TimTree/bingo-master-board" target="_blank">GitHub</a>.</p>
+              <p><strong>Envíame un comentario</strong> en la <a href="https://www.gamesbytim.com/2018/09/bingo-master-board-host-bingo-games-on.html" target="_blank">página de descripción del proyecto</a>.</p>
+              <p><strong>Reporta errores</strong> en la <a href="https://github.com/TimTree/bingo-master-board/issues" target="_blank">página de issues de GitHub</a>.</p>
+              <p><strong>Mira los <a class="textLink" onclick="hide('howToUseSlide');show('aboutCreditsSlide', 'grid');">Acerca/Créditos</a> del proyecto.</strong></p>
               <p><em>~Games by Tim</em></p>
             </div>
           </div>
         </div>
         <div class="helpFooter">
           <div class="helpFooterLabel" onclick="hide('howToUseSlide');show('titleSlide');">
-            Main Menu
+            Menú principal
           </div>
         </div>
       </div>
 
       <div id="aboutCreditsSlide">
-        <h2>About/Credits</h2>
+        <h2>Acerca/Créditos</h2>
         <div class="creditsNav">
           <div id="creditsNavLine"></div>
-          <div class="creditsNavText boldHelp" onclick="creditsHelp('About');" id="creditsAboutHeader">About</div>
-          <div class="creditsNavText" onclick="creditsHelp('Credits');" id="creditsCreditsHeader">Credits</div>
+          <div class="creditsNavText boldHelp" onclick="creditsHelp('About');" id="creditsAboutHeader">Acerca</div>
+          <div class="creditsNavText" onclick="creditsHelp('Credits');" id="creditsCreditsHeader">Créditos</div>
         </div>
         <div class="helpLine"></div>
         <div class="helpContent">
@@ -183,35 +183,35 @@
               <div>
                 <div class="flexCenter" style="flex-direction:column;">
                   <img src="./assets/img/appIcon.svg" width="300" style="box-shadow:5px 5px 10px rgba(0,0,0,0.25);border-radius:20px;">
-                  <p><em>Bingo Master Board</em></p>
+                  <p><em>Tablero Maestro de Bingo</em></p>
                 </div>
               </div>
               <div>
                 <div class="flexCenter" style="flex-direction:column;font-size:24px;line-height:1.8;">
                   <span style="margin-bottom:0.8em;font-size:26px;"><strong>Version 3.0.1</strong></span>
-                  <span><strong>Creator:</strong> Timothy Hsu</span>
-                  <span><strong>Released (PPT):</strong> Sept. 3, 2011</span>
-                  <span><strong>Released (Web):</strong> Sept. 17, 2018</span>
-                  <span><strong>Updated:</strong> Nov. 10, 2018</span>
-                  <span><strong>License:</strong> <a href="./LICENSE" target="_blank">MIT</a></span>
-                  <span style="margin-top:0.8em;font-size:22px;"><a href="https://github.com/TimTree/bingo-master-board" target="_blank">GitHub Repo</a>
-                  &nbsp;&nbsp;&nbsp;<a href="https://github.com/TimTree/bingo-master-board/releases" target="_blank">Release History</a></span>
-                  <span style="margin-top:0.8em;text-align:center;">For more projects by the creator, visit<br>
+                  <span><strong>Creador:</strong> Timothy Hsu</span>
+                  <span><strong>Lanzado (PPT):</strong> 3 de septiembre de 2011</span>
+                  <span><strong>Lanzado (Web):</strong> 17 de septiembre de 2018</span>
+                  <span><strong>Actualizado:</strong> 10 de noviembre de 2018</span>
+                  <span><strong>Licencia:</strong> <a href="./LICENSE" target="_blank">MIT</a></span>
+                  <span style="margin-top:0.8em;font-size:22px;"><a href="https://github.com/TimTree/bingo-master-board" target="_blank">Repositorio GitHub</a>
+                  &nbsp;&nbsp;&nbsp;<a href="https://github.com/TimTree/bingo-master-board/releases" target="_blank">Historial de lanzamientos</a></span>
+                  <span style="margin-top:0.8em;text-align:center;">Para más proyectos del creador, visita<br>
                     <a href="https://www.gamesbytim.com" target="_blank"><strong>Games by Tim</strong></a>.</span>
                 </div>
               </div>
             </div>
           </div>
           <div class="flexCenter" style="flex-direction:column;font-size:24px;" id="creditsCredits">
-            <p><strong>Games by Tim</strong> would like to thank:</p>
+            <p><strong>Games by Tim</strong> desea agradecer:</p>
             <div class="twoSections" style="grid-template-columns:1fr 50px 1fr;">
               <div>
                 <div style="display:flex;align-items:center;justify-content:center;">
                   <div>
-                  <p><strong>Microsoft PowerPoint</strong>, the program that got me started with games.</p>
-                  <p><strong>Make School</strong> for teaching me Web development skills utilized in this project</p>
-                  <p><strong>Hugh J. Ward</strong> for creating 75-ball Bingo</p>
-                  <p><strong>My family</strong> for supporting me through the tough stages of development</p>
+                  <p><strong>Microsoft PowerPoint</strong>, el programa que me inició en los juegos.</p>
+                  <p><strong>Make School</strong> por enseñarme habilidades de desarrollo web utilizadas en este proyecto</p>
+                  <p><strong>Hugh J. Ward</strong> por crear el Bingo de 75 bolas</p>
+                  <p><strong>Mi familia</strong> por apoyarme durante las etapas difíciles del desarrollo</p>
                   </div>
                 </div>
               </div>
@@ -219,9 +219,9 @@
               <div>
                 <div style="display:flex;align-items:center;justify-content:center;">
                   <div>
-                    <p><strong>Andrew Leung</strong> for his strong, encouraging enthusiasm.</p>
-                    <p><strong>rusnakcreative</strong> for motivating me to develop Bingo Master Board further.</p>
-                    <p><strong>You</strong> for using Bingo Master Board AND viewing the credits. You're awesome!</p>
+                    <p><strong>Andrew Leung</strong> por su fuerte y alentador entusiasmo.</p>
+                    <p><strong>rusnakcreative</strong> por motivarme a desarrollar más Tablero Maestro de Bingo.</p>
+                    <p><strong>Tú</strong> por usar Tablero Maestro de Bingo y ver los créditos. ¡Eres increíble!</p>
                   </div>
                 </div>
               </div>
@@ -230,7 +230,7 @@
         </div>
         <div class="helpFooter">
           <div class="helpFooterLabel" onclick="hide('aboutCreditsSlide');show('titleSlide');">
-            Main Menu
+            Menú principal
           </div>
         </div>
       </div>
@@ -238,14 +238,14 @@
       <div id="onboardingSlide">
         <div class="flexCenter" style="text-align:center;">
           <div>
-            <h3 style="margin-top:0.5em;">Welcome to <span style="color:#ce181e;">Bingo</span> <span style="color:#948a54;">Master Board</span></h3>
+            <h3 style="margin-top:0.5em;">Bienvenido a <span style="color:#ce181e;">Bingo</span> <span style="color:#948a54;">Tablero Maestro</span></h3>
             <p class="smallMargin">
               <img src="./assets/img/Onboarding.png" width="650">
             </p>
-            <p class="smallMargin" style="font-size:24px;"><strong>Host and manage</strong> Bingo games.</p>
-            <p class="smallMargin" style="font-size:24px;"><strong>Randomly draw</strong> Bingo balls. <strong>Set your own</strong> winning pattern and look.</p>
+            <p class="smallMargin" style="font-size:24px;"><strong>Organiza y administra</strong> juegos de Bingo.</p>
+            <p class="smallMargin" style="font-size:24px;"><strong>Saca al azar</strong> bolas de Bingo. <strong>Configura tu propio</strong> patrón ganador y aspecto.</p>
             <div class="helpFooterLabel" style="display:block;margin-top:1em;" onclick="hide('onboardingSlide');show('titleSlide');">
-              Begin
+              Comenzar
             </div>
           </div>
         </div>
@@ -255,8 +255,8 @@
         <div id="blocker"></div>
         <div class="controlsCol">
           <div style="margin:-6px 0 0 28px;">
-            <span class="smallButton" id="reset" onclick="resetBoard();">Reset</span>
-            <span class="smallButton" id="themes" onclick="hide('masterBoardSlide');show('settingsSlide', 'grid');">Themes</span>
+            <span class="smallButton" id="reset" onclick="resetBoard();">Reiniciar</span>
+            <span class="smallButton" id="themes" onclick="hide('masterBoardSlide');show('settingsSlide', 'grid');">Temas</span>
           </div>
           <div class="winningPatternDiv">
             <div class="bingoCard" onclick="hide('masterBoardSlide');show('winningPatternSlide', 'grid');">
@@ -299,15 +299,15 @@
           <div id="ballsDrawnRemaining">
             <span id="ballsDrawn">
               <span id="ballsDrawnNum" style="font-size:38px;font-weight:700;"></span>
-               &nbsp;drawn
+               &nbsp;extraídas
             </span>
             <span id="ballsRemaining">
               <span id="ballsRemainingNum" style="font-size:38px;font-weight:700;"></span>
-               &nbsp;remaining
+               &nbsp;restantes
            </span>
           </div>
-          <div class="boardToggle" id="hideBoard" onclick="toggleBlocker()">Hide Board</div>
-          <div class="boardToggle" id="showBoard" onclick="toggleBlocker()">Show Board</div>
+          <div class="boardToggle" id="hideBoard" onclick="toggleBlocker()">Ocultar tablero</div>
+          <div class="boardToggle" id="showBoard" onclick="toggleBlocker()">Mostrar tablero</div>
         </div>
         <div class="bingoCol bCol">
           <div class="bingoLetter" onclick="hideBingo('B', 'toggle');">
@@ -432,27 +432,27 @@
 
       <div id="settingsSlide">
         <div class="backButton" onclick="hide('settingsSlide');show('masterBoardSlide', 'grid');">
-          Go Back
+          Volver
         </div>
-        <h2>Themes</h2>
+        <h2>Temas</h2>
         <div class="helpContent">
           <div class="flexCenter">
             <div style="text-align:center;">
-              <p><strong>Background</strong></p>
+              <p><strong>Fondo</strong></p>
               <p class="themeSelection">
-                <span class="themeColor" id="classic" onclick="changeBackgroundColor('classic');">Classic</span>
-                <span class="themeColor" id="red" onclick="changeBackgroundColor('red');">Red</span>
-                <span class="themeColor" id="green" onclick="changeBackgroundColor('green');">Green</span>
+                <span class="themeColor" id="classic" onclick="changeBackgroundColor('classic');">Clásico</span>
+                <span class="themeColor" id="red" onclick="changeBackgroundColor('red');">Rojo</span>
+                <span class="themeColor" id="green" onclick="changeBackgroundColor('green');">Verde</span>
               </p>
               <p class="themeSelection" style="margin-bottom:1.5em;">
-                <span class="themeColor" id="blue" onclick="changeBackgroundColor('blue');">Blue</span>
-                <span class="themeColor" id="purple" onclick="changeBackgroundColor('purple');">Purple</span>
+                <span class="themeColor" id="blue" onclick="changeBackgroundColor('blue');">Azul</span>
+                <span class="themeColor" id="purple" onclick="changeBackgroundColor('purple');">Morado</span>
               </p>
-              <p><strong>Background Image</strong></p>
+              <p><strong>Imagen de fondo</strong></p>
               <p class="themeSelection" id="backgroundImageSelection"></p>
-              <p><strong>Overlay Transparency</strong></p>
+              <p><strong>Transparencia de superposición</strong></p>
               <p><input type="range" id="overlaySlider" min="0" max="100" oninput="changeOverlayOpacity(this.value)"></p>
-              <p><strong>Bingo Numbers</strong></p>
+              <p><strong>Números de Bingo</strong></p>
               <p style="display:flex;justify-content:center;">
                 <span id="bingoStyleBall" onclick="changeBingoStyle('ball');">
                   <span class="bingoBallBall bingoBallBallActiveB">15</span>
@@ -467,7 +467,7 @@
       </div>
 
       <div id="winningPatternSlide">
-        <h2>Winning Pattern</h2>
+        <h2>Patrón ganador</h2>
         <div class="helpContent">
           <div class="flexCenter">
             <div class="bigBingoCard">
@@ -504,31 +504,31 @@
             </div>
             <div>
               <div class="winningPatternNames">
-                <div class="winningName" onclick="winningPatternFromName();">No Pattern</div>
-                <div class="winningName" onclick="winningPatternFromName(1,5,21,25);">Four Corners</div>
-                <div class="winningName" onclick="winningPatternFromName(5,7,8,9,10,12,13,14,15,17,18,19,20,25);">Top Hat</div>
-                <div class="winningName" onclick="winningPatternFromName(1,2,3,4,5,10,15,20,25);">Letter L</div>
-                <div class="winningName" onclick="winningPatternFromName(7,8,9,12,14,17,18,19);">Frame Inside</div>
-                <div class="winningName" onclick="winningPatternFromName(3,7,8,11,12,13,14,15,17,18,23);">Tree</div>
-                <div class="winningName" onclick="winningPatternFromName(1,6,11,12,13,14,15,16,21);">Letter T</div>
-                <div class="winningName" onclick="winningPatternFromName(1,2,3,4,5,6,10,11,15,16,20,21,22,23,24,25);">Frame Outside</div>
-                <div class="winningName" onclick="winningPatternFromName(1,2,3,8,11,13,14,15,18,21,22,23);">Field Goal</div>
-                <div class="winningName" onclick="winningPatternFromName(1,5,7,9,13,17,19,21,25);">Letter X</div>
-                <div class="winningName" onclick="winningPatternFromName(3,8,11,12,13,14,15,18,23);">Plus Sign</div>
-                <div class="winningName" onclick="winningPatternFromName(3,7,9,11,15,17,19,23);">Diamond</div>
-                <div class="winningName" onclick="winningPatternFromName(1,7,13,14,15,17,21);">Letter Y</div>
-                <div class="winningName" onclick="winningPatternFromName(1,5,6,9,11,13,16,17,21);">Lucky 7</div>
-                <div class="winningName" onclick="winningPatternFromName(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25);">Blackout</div>
+                <div class="winningName" onclick="winningPatternFromName();">Sin patrón</div>
+                <div class="winningName" onclick="winningPatternFromName(1,5,21,25);">Cuatro esquinas</div>
+                <div class="winningName" onclick="winningPatternFromName(5,7,8,9,10,12,13,14,15,17,18,19,20,25);">Sombrero de copa</div>
+                <div class="winningName" onclick="winningPatternFromName(1,2,3,4,5,10,15,20,25);">Letra L</div>
+                <div class="winningName" onclick="winningPatternFromName(7,8,9,12,14,17,18,19);">Marco interno</div>
+                <div class="winningName" onclick="winningPatternFromName(3,7,8,11,12,13,14,15,17,18,23);">Árbol</div>
+                <div class="winningName" onclick="winningPatternFromName(1,6,11,12,13,14,15,16,21);">Letra T</div>
+                <div class="winningName" onclick="winningPatternFromName(1,2,3,4,5,6,10,11,15,16,20,21,22,23,24,25);">Marco externo</div>
+                <div class="winningName" onclick="winningPatternFromName(1,2,3,8,11,13,14,15,18,21,22,23);">Gol de campo</div>
+                <div class="winningName" onclick="winningPatternFromName(1,5,7,9,13,17,19,21,25);">Letra X</div>
+                <div class="winningName" onclick="winningPatternFromName(3,8,11,12,13,14,15,18,23);">Signo más</div>
+                <div class="winningName" onclick="winningPatternFromName(3,7,9,11,15,17,19,23);">Diamante</div>
+                <div class="winningName" onclick="winningPatternFromName(1,7,13,14,15,17,21);">Letra Y</div>
+                <div class="winningName" onclick="winningPatternFromName(1,5,6,9,11,13,16,17,21);">Siete de la suerte</div>
+                <div class="winningName" onclick="winningPatternFromName(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25);">Cartón lleno</div>
               </div>
               <div class="cardExplanation">
-                You can also click the Bingo tiles to form your own pattern.
+                También puedes hacer clic en las casillas de Bingo para formar tu propio patrón.
               </div>
             </div>
           </div>
         </div>
         <div class="helpFooter">
           <div class="helpFooterLabel" onclick="hideBingoLettersBasedOnWinningPattern();hide('winningPatternSlide');show('masterBoardSlide', 'grid');">
-            Go Back
+            Volver
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Resumen
- Traducir toda la interfaz y mensajes a español.
- Aumentar la opacidad de los números de bingo inactivos para mayor visibilidad.

## Pruebas
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dab150e44832ea424379fc1ea47f1