### PR TITLE
Remove bingo number transparency and add white theme

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -566,7 +566,7 @@ margin:0.5em 0;
 .bigBingoBallClass {
   background:#9b9b9b;
   border:2.5px solid #333;
-  opacity:0.4;
+  opacity:1;
 }
 
 #bigBingoBall {
@@ -579,7 +579,7 @@ margin:0.5em 0;
 }
 
 .bigBingoBallClass:hover {
-  opacity:0.7;
+  opacity:1;
 }
 
 #bigBingoLetter {
@@ -656,11 +656,11 @@ margin:0.5em 0;
   border-width: 1px;
   border-color:#333;
   color:#000;
-  opacity:0.4;
+  opacity:1;
 }
 
 .bingoBallBall:hover {
-  opacity:0.7;
+  opacity:1;
 }
 
 .bingoBallBallActiveB {
@@ -668,7 +668,7 @@ margin:0.5em 0;
   color:#6b3205;
   opacity:1;
 font-weight:700;
-  background:radial-gradient(circle at 31.5px 12px, rgba(247, 182, 128,0.85), rgba(228,108,10,0.85));
+  background:radial-gradient(circle at 31.5px 12px, rgba(247, 182, 128,1), rgba(228,108,10,1));
 }
 
 .bingoBallBallActiveI {
@@ -676,7 +676,7 @@ font-weight:700;
   color:#3e4f1f;
   opacity:1;
   font-weight:700;
-  background:radial-gradient(circle at 31.5px 12px, rgba(176, 204, 120,0.85), rgba(135, 170, 63,0.85));
+  background:radial-gradient(circle at 31.5px 12px, rgba(176, 204, 120,1), rgba(135, 170, 63,1));
 }
 
 .bingoBallBallActiveN {
@@ -684,7 +684,7 @@ font-weight:700;
   color:#194551;
   opacity:1;
   font-weight:700;
-  background:radial-gradient(circle at 31.5px 12px, rgba(108, 201, 226,0.85), rgba(84, 165, 188,0.85));
+  background:radial-gradient(circle at 31.5px 12px, rgba(108, 201, 226,1), rgba(84, 165, 188,1));
 }
 
 .bingoBallBallActiveG {
@@ -692,7 +692,7 @@ font-weight:700;
   color:#352944;
   opacity:1;
   font-weight:700;
-  background:radial-gradient(circle at 31.5px 12px, rgba(195, 164, 234,0.85), rgba(159, 129, 193,0.85));
+  background:radial-gradient(circle at 31.5px 12px, rgba(195, 164, 234,1), rgba(159, 129, 193,1));
 }
 
 .bingoBallBallActiveO {
@@ -700,11 +700,11 @@ font-weight:700;
   color:#5e2221;
   opacity:1;
   font-weight:700;
-  background:radial-gradient(circle at 31.5px 12px, rgba(255, 138, 135,0.85), rgba(221, 98, 95,0.85));
+  background:radial-gradient(circle at 31.5px 12px, rgba(255, 138, 135,1), rgba(221, 98, 95,1));
 }
 
 .bingoBallBallActiveB:hover, .bingoBallBallActiveI:hover, .bingoBallBallActiveN:hover, .bingoBallBallActiveG:hover, .bingoBallBallActiveO:hover {
-  opacity:0.8;
+  opacity:1;
 }
 
 .bingoBallVintage {
@@ -718,11 +718,11 @@ color:gray;
   font-size:52px;
   cursor:pointer;
   color:#000;
-  opacity:0.35;
+  opacity:1;
 }
 
 .bingoBallVintage:hover {
-  opacity:0.7;
+  opacity:1;
 }
 
 .bingoBallVintageActive {
@@ -731,17 +731,17 @@ color:gray;
 }
 
 .bingoBallVintageActive:hover {
-  opacity:0.75;
+  opacity:1;
 }
 
 .bigBingoBallVintage {
   opacity:1;
   font-weight:700;
-  background:rgba(155, 155, 155,0.5);
+  background:rgb(155, 155, 155);
 }
 
 .bigBingoBallVintage:hover {
-  opacity:0.75;
+  opacity:1;
 }
 
 #bingoStyleBall {
@@ -866,7 +866,7 @@ color:gray;
 
 .bingoCard:hover {
   cursor:pointer;
-  opacity:0.75;
+  opacity:1;
 }
 
 .bigBingoCard {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -347,17 +347,21 @@ function changeBG(color) {
     overlayRGB = "150,206,129";
     document.getElementById("blocker").style.backgroundImage = "linear-gradient(#a9c571, #77933c)";
   } else if (color === "blue") {
-    newColor = "rgb(139, 199, 226)";
-    overlayRGB = "139,199,226";
-    document.getElementById("blocker").style.backgroundImage = "linear-gradient(#9abce6, #558ed5)";
-  } else if (color === "purple") {
-    newColor = "rgb(189, 176, 216)";
-    overlayRGB = "189,176,216";
-    document.getElementById("blocker").style.backgroundImage = "linear-gradient(#b3a2c7, #725892)";
-  } else {
-    newColor = "radial-gradient(#f7eaab, #bfbb73)";
-    overlayRGB = "247,234,171";
-  }
+      newColor = "rgb(139, 199, 226)";
+      overlayRGB = "139,199,226";
+      document.getElementById("blocker").style.backgroundImage = "linear-gradient(#9abce6, #558ed5)";
+    } else if (color === "purple") {
+      newColor = "rgb(189, 176, 216)";
+      overlayRGB = "189,176,216";
+      document.getElementById("blocker").style.backgroundImage = "linear-gradient(#b3a2c7, #725892)";
+    } else if (color === "white") {
+      newColor = "#ffffff";
+      overlayRGB = "255,255,255";
+      document.getElementById("blocker").style.backgroundImage = "linear-gradient(#f2f2f2, #cccccc)";
+    } else {
+      newColor = "radial-gradient(#f7eaab, #bfbb73)";
+      overlayRGB = "247,234,171";
+    }
   if (saveData.backgroundImage) {
     const bgUrl = `url('./assets/backgrounds/${saveData.backgroundImage}') center/cover no-repeat`;
     const alpha = saveData.overlayOpacity / 100;
@@ -734,25 +738,28 @@ function setUpMasterBoard() {
 }
 
 function setUpSettings() {
-  document.getElementById("classic").style.backgroundColor = "";
-  document.getElementById("red").style.backgroundColor = "";
-  document.getElementById("green").style.backgroundColor = "";
-  document.getElementById("blue").style.backgroundColor = "";
-  document.getElementById("purple").style.backgroundColor = "";
+    document.getElementById("classic").style.backgroundColor = "";
+    document.getElementById("red").style.backgroundColor = "";
+    document.getElementById("green").style.backgroundColor = "";
+    document.getElementById("blue").style.backgroundColor = "";
+    document.getElementById("purple").style.backgroundColor = "";
+    document.getElementById("white").style.backgroundColor = "";
   document.getElementById("bingoStyleBall").style.backgroundColor = "";
   document.getElementById("bingoStyleVintage").style.backgroundColor = "";
   populateBackgroundImageOptions();
-  if (saveData.themeColor === "classic") {
-    document.getElementById("classic").style.backgroundColor = "rgba(148,138,84,0.28)";
-  } else if (saveData.themeColor === "red") {
-    document.getElementById("red").style.backgroundColor = "rgba(255,0,0,0.2)";
-  } else if (saveData.themeColor === "green") {
-    document.getElementById("green").style.backgroundColor = "rgba(0,128,0,0.2)";
-  } else if (saveData.themeColor === "blue") {
-    document.getElementById("blue").style.backgroundColor = "rgba(51,102,255,0.2)";
-  } else if (saveData.themeColor === "purple") {
-    document.getElementById("purple").style.backgroundColor = "rgba(164,70,153,0.2)";
-  }
+    if (saveData.themeColor === "classic") {
+      document.getElementById("classic").style.backgroundColor = "rgba(148,138,84,0.28)";
+    } else if (saveData.themeColor === "red") {
+      document.getElementById("red").style.backgroundColor = "rgba(255,0,0,0.2)";
+    } else if (saveData.themeColor === "green") {
+      document.getElementById("green").style.backgroundColor = "rgba(0,128,0,0.2)";
+    } else if (saveData.themeColor === "blue") {
+      document.getElementById("blue").style.backgroundColor = "rgba(51,102,255,0.2)";
+    } else if (saveData.themeColor === "purple") {
+      document.getElementById("purple").style.backgroundColor = "rgba(164,70,153,0.2)";
+    } else if (saveData.themeColor === "white") {
+      document.getElementById("white").style.backgroundColor = "rgba(0,0,0,0.1)";
+    }
   if (saveData.bingoStyle === "ball") {
     document.getElementById("bingoStyleBall").style.backgroundColor = "rgba(0,0,0,0.15)";
   } else if (saveData.bingoStyle === "vintage") {

--- a/index.html
+++ b/index.html
@@ -447,6 +447,7 @@
               <p class="themeSelection" style="margin-bottom:1.5em;">
                 <span class="themeColor" id="blue" onclick="changeBackgroundColor('blue');">Azul</span>
                 <span class="themeColor" id="purple" onclick="changeBackgroundColor('purple');">Morado</span>
+                <span class="themeColor" id="white" onclick="changeBackgroundColor('white');">Blanco</span>
               </p>
               <p><strong>Imagen de fondo</strong></p>
               <p class="themeSelection" id="backgroundImageSelection"></p>


### PR DESCRIPTION
## Summary
- remove opacity from bingo numbers and vintage styles
- add "Blanco" theme option with white background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e481f0a18832ea2b4c7601b894f03