### PR TITLE
Add video presentation screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
 .DS_Store
 node_modules
+
+assets/videos/*.mp4

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -952,3 +952,34 @@ color:gray;
   display:grid;
   grid-template-columns: 1fr 1fr;
 }
+
+#ceSlide {
+  display:none;
+  width:100%;
+  height:100%;
+  position:relative;
+  background-color:#000;
+  justify-content:center;
+  align-items:center;
+}
+
+#ceSlide video {
+  max-width:100%;
+  max-height:100%;
+}
+
+#videoControls {
+  position:absolute;
+  top:0;
+  left:0;
+}
+
+.videoFullScreen {
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  z-index:1000;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -984,3 +984,21 @@ function keyboardNavCredits(leftOrRight) {
     }
   }
 }
+
+function presentVideo() {
+  hide('masterBoardSlide');
+  show('ceSlide', 'flex');
+  const controls = document.getElementById('videoControls');
+  controls.style.display = 'none';
+  const vid = document.getElementById('ceVideo');
+  vid.classList.add('videoFullScreen');
+  vid.play();
+  vid.addEventListener('click', exitVideoPresentation);
+}
+
+function exitVideoPresentation() {
+  const vid = document.getElementById('ceVideo');
+  vid.classList.remove('videoFullScreen');
+  document.getElementById('videoControls').style.display = 'block';
+  vid.removeEventListener('click', exitVideoPresentation);
+}

--- a/index.html
+++ b/index.html
@@ -257,6 +257,8 @@
           <div style="margin:-6px 0 0 28px;">
             <span class="smallButton" id="reset" onclick="resetBoard();">Reiniciar</span>
             <span class="smallButton" id="themes" onclick="hide('masterBoardSlide');show('settingsSlide', 'grid');">Temas</span>
+            <span class="smallButton" id="ceLink" onclick="hide('masterBoardSlide');show('ceSlide', 'flex');">CE</span>
+            <span class="smallButton" id="presentar" onclick="presentVideo();">Presentar</span>
           </div>
           <div class="winningPatternDiv">
             <div class="bingoCard" onclick="hide('masterBoardSlide');show('winningPatternSlide', 'grid');">
@@ -533,7 +535,15 @@
           </div>
         </div>
       </div>
-
+      <div id="ceSlide">
+        <div id="videoControls" style="margin:-6px 0 0 28px;">
+          <span class="smallButton" onclick="hide('ceSlide');show('masterBoardSlide', 'grid');">CE</span>
+          <span class="smallButton" onclick="resetBoard();">Reiniciar</span>
+          <span class="smallButton" onclick="hide('ceSlide');show('settingsSlide', 'grid');">Temas</span>
+          <span class="smallButton" onclick="presentVideo();">Presentar</span>
+        </div>
+        <video id="ceVideo" src="./assets/videos/loop.mp4" loop autoplay muted></video>
+      </div>
     </div>
 
     <script src="./assets/js/featureChecker.js"></script>


### PR DESCRIPTION
## Summary
- add CE and Presentar controls to master board
- introduce CE slide for looping video presentation
- support full screen video mode when presenting
- remove sample `loop.mp4` from repository and ignore mp4 video files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e526ba160832e8f505ea6c5b5d5c7